### PR TITLE
Add startframe and endframe to Movie.m; bug fix in extractContourMeanRadius.m

### DIFF
--- a/+CellVision3D/@CellAnalyzer/extractContourMeanRadius.m
+++ b/+CellVision3D/@CellAnalyzer/extractContourMeanRadius.m
@@ -11,7 +11,7 @@ for icell=1:length(cells)
     % number contours
     for icontour=1:numcontours
 %         radii = zeros(contours(icontour).numframes,1);
-        radii =(contours(icontour).getVolume*3/4/pi)^(1/3) ...
+        radii =(contours(icontour).getVolume*3/4/pi).^(1/3) ...
                 *contours(icontour).pix2um;
         contours(icontour).setUserData('mean_radius',radii);
     end

--- a/+CellVision3D/@Movie/Movie.m
+++ b/+CellVision3D/@Movie/Movie.m
@@ -17,6 +17,9 @@ classdef Movie < CellVision3D.HObject
             % data information
         numchannels % number of channels
         channels % channel handles
+        
+        startframe = nan
+        endframe = nan
     end
     
     properties (SetAccess = public)

--- a/+CellVision3D/@Movie/load.m
+++ b/+CellVision3D/@Movie/load.m
@@ -72,10 +72,19 @@ else
     obj.numstacks=obj.sizeZ;
     obj.numframes=omeMeta1.getPixelsSizeT(0).getValue();
     
+    if ~isnan(obj.startframe) && ~isnan(obj.endframe)
+        obj.numframes = obj.endframe - obj.startframe + 1;
+    else
+        obj.startframe = 1;
+        obj.endframe = obj.numframes;
+    end
     
     for ichannel=1:obj.numchannels
+        
         chooseind=mod(floor((0:length(mov)-1)/obj.numstacks),obj.numchannels)==ichannel-1;
-        obj.channels(ichannel).load(mov(chooseind),obj);
+        channelmov = mov(chooseind);
+        obj.channels(ichannel).load(channelmov(...
+            (obj.startframe-1)*obj.numstacks+1:obj.endframe*obj.numstacks),obj);
     end
     
 end


### PR DESCRIPTION
**Add startframe and endframe to Movie.m** --
Yao added in Movie.m the properties: 'startframe' and 'endframe' and incorporated operations for loading a file with specified frames in @Movie/load.m.

**Bug fix in extractContourMeanRadius.m** --
When running second to last segment in sample_script_manualsegment.m (%% analyze the cells), the following error popped up: 
Error using  ^ 
Inputs must be a scalar and a square matrix.
To compute elementwise POWER, use POWER (.^) instead.

Error in CellVision3D.CellAnalyzer.extractContourMeanRadius (line 14)
        radii =(contours(icontour).getVolume*3/4/pi)^(1/3) ...

To remedy this, I added a '.' right before '^' in line 14.